### PR TITLE
Add to sidecar discovery edge cases

### DIFF
--- a/src/helpers/copy-with-json-sidecar.ts
+++ b/src/helpers/copy-with-json-sidecar.ts
@@ -12,7 +12,7 @@ export async function copyWithJsonSidecar(fileInfo: FileInfo, destDir: string): 
   const destName = fileInfo.outputFileName ? fileInfo.outputFileName : fileInfo.fileName;  // use the outputFileName if set or fall back to the original fileName otherwise
 
   await copyFile(fileInfo.filePath, resolve(destDir, destName));
-  if (fileInfo.jsonFileExists && fileInfo.jsonFileName && fileInfo.jsonFilePath) {
+  if (fileInfo.jsonFileExists && fileInfo.jsonFileHasSize && fileInfo.jsonFileName && fileInfo.jsonFilePath) {
     await copyFile(fileInfo.jsonFilePath, resolve(destDir, fileInfo.jsonFileName));
   }
 

--- a/src/helpers/get-all-files-except-json.ts
+++ b/src/helpers/get-all-files-except-json.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import { basename, extname, resolve } from 'path';
 import { CONFIG } from '../config';
 import { FileInfo } from '../models/file-info';
@@ -33,6 +33,7 @@ export async function getAllFilesExceptJson(inputDir: string, outputDir: string)
     const jsonFilePath = getCompanionJsonPathForMediaFile(filePath);   // intentionally not including a check for isMediaFile here because some unsupported files may nevertheless contain JSON sidecars
     const jsonFileName = jsonFilePath ? basename(jsonFilePath) : null;
     const jsonFileExists = jsonFilePath ? existsSync(jsonFilePath) : false;
+    const jsonFileHasSize = jsonFilePath && jsonFileExists ? statSync(jsonFilePath).size !== 0: false;
     
     const outputFileName = isMediaFile ? generateUniqueOutputFileName(filePath, allUsedOutputFilesLowerCased) : null;
     const outputFilePath = isMediaFile ? resolve(outputDir, <string>outputFileName) : null;
@@ -47,6 +48,7 @@ export async function getAllFilesExceptJson(inputDir: string, outputDir: string)
       jsonFilePath,
       jsonFileName,
       jsonFileExists,
+      jsonFileHasSize,
       outputFileName,
       outputFilePath,
     });

--- a/src/helpers/read-photo-taken-time-from-google-json.ts
+++ b/src/helpers/read-photo-taken-time-from-google-json.ts
@@ -5,7 +5,7 @@ import { FileInfo } from '../models/file-info'
 const { readFile } = fspromises;
 
 export async function readPhotoTakenTimeFromGoogleJson(mediaFile: FileInfo): Promise<string|null> {
-  if (!mediaFile.jsonFilePath || !mediaFile.jsonFileExists) {
+  if (!mediaFile.jsonFilePath || !mediaFile.jsonFileExists || !mediaFile.jsonFileHasSize) {
     return null;
   }
 

--- a/src/helpers/update-exif-metadata.ts
+++ b/src/helpers/update-exif-metadata.ts
@@ -21,7 +21,7 @@ export async function updateExifMetadata(fileInfo: FileInfo, timeTaken: string, 
 
   } catch (error) {
     await copyFile(fileInfo.outputFilePath,  resolve(errorDir, fileInfo.fileName));
-    if (fileInfo.jsonFileExists && fileInfo.jsonFileName && fileInfo.jsonFilePath) {
+    if (fileInfo.jsonFileExists && fileInfo.jsonFileHasSize && fileInfo.jsonFileName && fileInfo.jsonFilePath) {
       await copyFile(fileInfo.jsonFilePath, resolve(errorDir, fileInfo.jsonFileName));
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,11 @@ class GooglePhotosExif extends Command {
         this.log (`    copying ${fi.fileName} to the errors directory due to missing JSON sidecar.`);
         copyWithJsonSidecar (fi, directories.error);   
       }
+      else if (!fi.jsonFileHasSize) {
+        totalMissingJson++;
+        this.log (`    copying ${fi.fileName} to the errors directory due to empty JSON sidecar.`);
+        copyWithJsonSidecar (fi, directories.error);
+      }
     }
     this.log (`--- ${totalFilesCount} total files, ${mediaFiles.length} supported media files, of which ${totalMissingJson} media files' JSON sidecar could not be located. ---`);
   

--- a/src/models/file-info.ts
+++ b/src/models/file-info.ts
@@ -9,6 +9,7 @@ export interface FileInfo {
   jsonFilePath: string|null;
   jsonFileName: string|null;
   jsonFileExists: boolean;
+  jsonFileHasSize: boolean;
 
   outputFileName: string|null;
   outputFilePath: string|null;


### PR DESCRIPTION
Edge cases included:
* `.mp4` can use jpeg and heic json files: https://github.com/mattwilson1024/google-photos-exif/issues/26
* Counters may collide with other rules
* Long filenames are truncated: https://github.com/mattwilson1024/google-photos-exif/issues/28
* Some json files have `.j` and `.jp` as the media extension

Signed-off-by: arewm <arewm@users.noreply.github.com>